### PR TITLE
Support arbitrary keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Experimental FASTER wrapper for Rust
 
-Includes experimental C interface for FASTER. It currently assumes the KEY type is u64 however the VALUE type supports arbitrary serialisable structs. This wrapper is only focusing on Linux support.
+Includes experimental C interface for FASTER. It is a generic implementation of FASTER that allows arbitrary Key-Value pairs to be stored. This wrapper is only focusing on Linux support.
 
 
 It is probably a good idea to make sure you can compile the C++ version before you start playing around with this wrapper.
@@ -10,7 +10,7 @@ It is probably a good idea to make sure you can compile the C++ version before y
 *Make sure you clone the submodules as well*, this is best done by cloning with `git clone --recurse-submodules`.
 
 ## The interface
-This wrapper attempts to remain true to the original FASTER design by exposing a similar interface to that which is provided by the original C++ version. Users may define their own value types (that implement the `FasterValue` trait) and provide custom logic for Read-Modify-Write operations.
+This wrapper attempts to remain true to the original FASTER design by exposing a similar interface to that which is provided by the original C++ version. Users may define their own Key-Value types (that implement the `FasterKey` and `FasterValue` traits) and provide custom logic for Read-Modify-Write operations.
 
 
 The `Read`, `Upsert` and `RMW` operations all require a monotonic serial number to form the sequence of operations that will be persisted by FASTER. `Read` operations require a serial number so that at a CPR checkpoint boundary, FASTER guarantees that the reads before that point have accessed no data updates after the checkpoint. If persistence is not important, the serial number can safely be set to `1` for all operations (as is done in the examples above).
@@ -26,11 +26,11 @@ Try it out by running `cargo run --example basic`.
 ```rust,no_run
 extern crate faster_kvs;
 
-use faster_kvs::{FasterKv, status};
+use faster_kvs::{status, FasterKv};
 use std::sync::mpsc::Receiver;
 
 fn main() {
-    const TABLE_SIZE: u64  = 1 << 14;
+    const TABLE_SIZE: u64 = 1 << 14;
     const LOG_SIZE: u64 = 17179869184;
 
     // Create a Key-Value Store
@@ -41,13 +41,13 @@ fn main() {
 
         // Upsert
         for i in 0..1000 {
-            let upsert = store.upsert(key0 + i, &(value0 + i), i);
+            let upsert = store.upsert(&(key0 + i), &(value0 + i), i);
             assert!(upsert == status::OK || upsert == status::PENDING);
         }
 
         // Read-Modify-Write
         for i in 0..1000 {
-            let rmw = store.rmw(key0 + i, &(5 as u64), i + 1000);
+            let rmw = store.rmw(&(key0 + i), &(5 as u64), i + 1000);
             assert!(rmw == status::OK || rmw == status::PENDING);
         }
 
@@ -56,7 +56,7 @@ fn main() {
         // Read
         for i in 0..1000 {
             // Note: need to provide type annotation for the Receiver
-            let (read, recv): (u8, Receiver<u64>) = store.read(key0 + i, i);
+            let (read, recv): (u8, Receiver<u64>) = store.read(&(key0 + i), i);
             assert!(read == status::OK || read == status::PENDING);
             let val = recv.recv().unwrap();
             assert_eq!(val, value0 + i + modification);
@@ -65,7 +65,7 @@ fn main() {
 
         // Clear used storage
         match store.clean_storage() {
-            Ok(()) => {},
+            Ok(()) => {}
             Err(_err) => panic!("Unable to clear FASTER directory"),
         }
     } else {
@@ -73,6 +73,66 @@ fn main() {
     }
 }
 ```
+
+## Using custom keys
+`struct`s that can be (de)serialised using [serde](https://crates.rs/crates/serde) are supported as keys. In order to use such a `struct`, it is necessary to derive the implementations of `Serializable` and `Deserializable` from `serde-derive`. All types implementing these two traits will automatically implement `FasterKey` and thus be usable as a Key.
+
+The following example shows a basic struct being used as a key. Try it out by running `cargo run --example custom_keys`.
+
+```rust,no-run
+extern crate faster_kvs;
+extern crate serde_derive;
+
+use faster_kvs::{status, FasterKv};
+use serde_derive::{Deserialize, Serialize};
+use std::sync::mpsc::Receiver;
+
+// Note: Debug annotation is just for printing later
+#[derive(Serialize, Deserialize, Debug)]
+struct MyKey {
+    foo: String,
+    bar: String,
+}
+
+fn main() {
+    const TABLE_SIZE: u64 = 1 << 14;
+    const LOG_SIZE: u64 = 17179869184;
+
+    // Create a Key-Value Store
+    if let Ok(store) = FasterKv::new(
+        TABLE_SIZE,
+        LOG_SIZE,
+        String::from("example_custom_values_storage"),
+    ) {
+        let key = MyKey {
+            foo: String::from("Hello"),
+            bar: String::from("World"),
+        };
+        let value: u64 = 1;
+
+        // Upsert
+        let upsert = store.upsert(&key, &value, 1);
+        assert!(upsert == status::OK || upsert == status::PENDING);
+
+        assert!(store.size() > 0);
+
+        // Note: need to provide type annotation for the Receiver
+        let (read, recv): (u8, Receiver<u64>) = store.read(&key, 1);
+        assert!(read == status::OK || read == status::PENDING);
+        let val = recv.recv().unwrap();
+        println!("Key: {:?}, Value: {}", key, val);
+
+        // Clear used storage
+        match store.clean_storage() {
+            Ok(()) => {}
+            Err(_err) => panic!("Unable to clear FASTER directory"),
+        }
+    } else {
+        panic!("Unable to create FASTER directory");
+    }
+}
+```
+
 
 ## Using custom values
 `struct`s that can be (de)serialised using [serde](https://crates.rs/crates/serde) are supported as values. In order to use such a `struct`, it is necessary to derive the implementations of `Serializable` and `Deserializable` from `serde-derive`. It is also necessary to implement the `FasterValue` trait which exposes an `rmw()` function. This function can be used to implement custom logic for Read-Modify-Write operations or simply left with an `unimplemented!()` macro. In the latter case, any attempt to invoke a RMW operation will cause a panic.
@@ -83,7 +143,7 @@ The following example shows a basic struct being used as a value. Try it out by 
 extern crate faster_kvs;
 extern crate serde_derive;
 
-use faster_kvs::{FasterKv, FasterValue,status};
+use faster_kvs::{status, FasterKv, FasterValue};
 use serde_derive::{Deserialize, Serialize};
 use std::sync::mpsc::Receiver;
 
@@ -101,29 +161,36 @@ impl FasterValue<'_, MyValue> for MyValue {
 }
 
 fn main() {
-    const TABLE_SIZE: u64  = 1 << 14;
+    const TABLE_SIZE: u64 = 1 << 14;
     const LOG_SIZE: u64 = 17179869184;
 
     // Create a Key-Value Store
-    if let Ok(store) = FasterKv::new(TABLE_SIZE, LOG_SIZE, String::from("example_custom_values_storage")) {
+    if let Ok(store) = FasterKv::new(
+        TABLE_SIZE,
+        LOG_SIZE,
+        String::from("example_custom_values_storage"),
+    ) {
         let key: u64 = 1;
-        let value = MyValue { foo: String::from("Hello"), bar: String::from("World") };
+        let value = MyValue {
+            foo: String::from("Hello"),
+            bar: String::from("World"),
+        };
 
         // Upsert
-        let upsert = store.upsert(key, &value, 1);
+        let upsert = store.upsert(&key, &value, 1);
         assert!(upsert == status::OK || upsert == status::PENDING);
 
         assert!(store.size() > 0);
 
         // Note: need to provide type annotation for the Receiver
-        let (read, recv): (u8, Receiver<MyValue>) = store.read(key, 1);
+        let (read, recv): (u8, Receiver<MyValue>) = store.read(&key, 1);
         assert!(read == status::OK || read == status::PENDING);
         let val = recv.recv().unwrap();
         println!("Key: {}, Value: {:?}", key, val);
 
         // Clear used storage
         match store.clean_storage() {
-            Ok(()) => {},
+            Ok(()) => {}
             Err(_err) => panic!("Unable to clear FASTER directory"),
         }
     } else {

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -15,13 +15,13 @@ fn main() {
 
         // Upsert
         for i in 0..1000 {
-            let upsert = store.upsert(key0 + i, &(value0 + i), i);
+            let upsert = store.upsert(&(key0 + i), &(value0 + i), i);
             assert!(upsert == status::OK || upsert == status::PENDING);
         }
 
         // Read-Modify-Write
         for i in 0..1000 {
-            let rmw = store.rmw(key0 + i, &(5 as u64), i + 1000);
+            let rmw = store.rmw(&(key0 + i), &(5 as u64), i + 1000);
             assert!(rmw == status::OK || rmw == status::PENDING);
         }
 
@@ -30,7 +30,7 @@ fn main() {
         // Read
         for i in 0..1000 {
             // Note: need to provide type annotation for the Receiver
-            let (read, recv): (u8, Receiver<u64>) = store.read(key0 + i, i);
+            let (read, recv): (u8, Receiver<u64>) = store.read(&(key0 + i), i);
             assert!(read == status::OK || read == status::PENDING);
             let val = recv.recv().unwrap();
             assert_eq!(val, value0 + i + modification);

--- a/examples/custom_keys.rs
+++ b/examples/custom_keys.rs
@@ -1,0 +1,51 @@
+extern crate faster_kvs;
+extern crate serde_derive;
+
+use faster_kvs::{status, FasterKv};
+use serde_derive::{Deserialize, Serialize};
+use std::sync::mpsc::Receiver;
+
+// Note: Debug annotation is just for printing later
+#[derive(Serialize, Deserialize, Debug)]
+struct MyKey {
+    foo: String,
+    bar: String,
+}
+
+fn main() {
+    const TABLE_SIZE: u64 = 1 << 14;
+    const LOG_SIZE: u64 = 17179869184;
+
+    // Create a Key-Value Store
+    if let Ok(store) = FasterKv::new(
+        TABLE_SIZE,
+        LOG_SIZE,
+        String::from("example_custom_values_storage"),
+    ) {
+        let key = MyKey {
+            foo: String::from("Hello"),
+            bar: String::from("World"),
+        };
+        let value: u64 = 1;
+
+        // Upsert
+        let upsert = store.upsert(&key, &value, 1);
+        assert!(upsert == status::OK || upsert == status::PENDING);
+
+        assert!(store.size() > 0);
+
+        // Note: need to provide type annotation for the Receiver
+        let (read, recv): (u8, Receiver<u64>) = store.read(&key, 1);
+        assert!(read == status::OK || read == status::PENDING);
+        let val = recv.recv().unwrap();
+        println!("Key: {:?}, Value: {}", key, val);
+
+        // Clear used storage
+        match store.clean_storage() {
+            Ok(()) => {}
+            Err(_err) => panic!("Unable to clear FASTER directory"),
+        }
+    } else {
+        panic!("Unable to create FASTER directory");
+    }
+}

--- a/examples/custom_values.rs
+++ b/examples/custom_values.rs
@@ -35,13 +35,13 @@ fn main() {
         };
 
         // Upsert
-        let upsert = store.upsert(key, &value, 1);
+        let upsert = store.upsert(&key, &value, 1);
         assert!(upsert == status::OK || upsert == status::PENDING);
 
         assert!(store.size() > 0);
 
         // Note: need to provide type annotation for the Receiver
-        let (read, recv): (u8, Receiver<MyValue>) = store.read(key, 1);
+        let (read, recv): (u8, Receiver<MyValue>) = store.read(&key, 1);
         assert!(read == status::OK || read == status::PENDING);
         let val = recv.recv().unwrap();
         println!("Key: {}, Value: {:?}", key, val);

--- a/examples/sum_store_single.rs
+++ b/examples/sum_store_single.rs
@@ -49,7 +49,7 @@ fn populate() -> () {
 
         for i in 0..NUM_OPS {
             let idx = i as u64;
-            store.rmw(idx % NUM_UNIQUE_KEYS, &(1 as u64), idx);
+            store.rmw(&(idx % NUM_UNIQUE_KEYS), &(1 as u64), idx);
 
             if (idx % CHECKPOINT_INTERVAL) == 0 {
                 let check = store.checkpoint().unwrap();
@@ -98,7 +98,7 @@ fn recover(token: String) -> () {
                 for i in 0..NUM_OPS {
                     let idx = i as u64;
                     let (status, recv): (u8, Receiver<u64>) =
-                        recover_store.read(idx % NUM_UNIQUE_KEYS, idx);
+                        recover_store.read(&(idx % NUM_UNIQUE_KEYS), idx);
                     if let Ok(val) = recv.recv() {
                         let expected = *expected_results
                             .get((idx % NUM_UNIQUE_KEYS) as usize)

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -1,6 +1,9 @@
 use crate::faster_value::FasterValue;
+use crate::FasterKey;
 use serde::{Deserialize, Serialize};
 use std::ops::Add;
+
+impl<'a, T> FasterKey<'a, T> for T where T: Serialize + Deserialize<'a> {}
 
 macro_rules! primitive_impl {
     ($ty:ident, $method:ident $($cast:tt)*) => {

--- a/tests/basic_tests.rs
+++ b/tests/basic_tests.rs
@@ -17,10 +17,10 @@ fn faster_check() {
     let key: u64 = 1;
     let value: u64 = 1337;
 
-    let upsert = store.upsert(key, &value, 1);
+    let upsert = store.upsert(&key, &value, 1);
     assert!((upsert == status::OK || upsert == status::PENDING) == true);
 
-    let rmw = store.rmw(key, &(5 as u64), 1);
+    let rmw = store.rmw(&key, &(5 as u64), 1);
     assert!(rmw == status::OK);
 
     assert!(store.size() > 0);
@@ -34,10 +34,10 @@ fn faster_read_inserted_value() {
     let key: u64 = 1;
     let value: u64 = 1337;
 
-    let upsert = store.upsert(key, &value, 1);
+    let upsert = store.upsert(&key, &value, 1);
     assert!((upsert == status::OK || upsert == status::PENDING) == true);
 
-    let (res, recv): (u8, Receiver<u64>) = store.read(key, 1);
+    let (res, recv): (u8, Receiver<u64>) = store.read(&key, 1);
     assert!(res == status::OK);
     assert!(recv.recv().unwrap() == value);
 }
@@ -49,7 +49,7 @@ fn faster_read_missing_value_recv_error() {
     let store = FasterKv::new(TABLE_SIZE, LOG_SIZE, dir_path).unwrap();
     let key: u64 = 1;
 
-    let (res, recv): (u8, Receiver<u64>) = store.read(key, 1);
+    let (res, recv): (u8, Receiver<u64>) = store.read(&key, 1);
     assert!(res == status::NOT_FOUND);
     assert!(recv.recv().is_err());
 }
@@ -63,17 +63,17 @@ fn faster_rmw_changes_values() {
     let value: u64 = 1337;
     let modification: u64 = 100;
 
-    let upsert = store.upsert(key, &value, 1);
+    let upsert = store.upsert(&key, &value, 1);
     assert!((upsert == status::OK || upsert == status::PENDING) == true);
 
-    let (res, recv): (u8, Receiver<u64>) = store.read(key, 1);
+    let (res, recv): (u8, Receiver<u64>) = store.read(&key, 1);
     assert!(res == status::OK);
     assert!(recv.recv().unwrap() == value);
 
-    let rmw = store.rmw(key, &modification, 1);
+    let rmw = store.rmw(&key, &modification, 1);
     assert!((rmw == status::OK || rmw == status::PENDING) == true);
 
-    let (res, recv): (u8, Receiver<u64>) = store.read(key, 1);
+    let (res, recv): (u8, Receiver<u64>) = store.read(&key, 1);
     assert!(res == status::OK);
     assert!(recv.recv().unwrap() == value + modification);
 }
@@ -86,10 +86,10 @@ fn faster_rmw_without_upsert() {
     let key: u64 = 1;
     let modification: u64 = 100;
 
-    let rmw = store.rmw(key, &modification, 1);
+    let rmw = store.rmw(&key, &modification, 1);
     assert!((rmw == status::OK || rmw == status::PENDING) == true);
 
-    let (res, recv): (u8, Receiver<u64>) = store.read(key, 1);
+    let (res, recv): (u8, Receiver<u64>) = store.read(&key, 1);
     assert!(res == status::OK);
     assert!(recv.recv().unwrap() == modification);
 }
@@ -103,17 +103,17 @@ fn faster_rmw_string() {
     let value = String::from("Hello, ");
     let modification = String::from("World!");
 
-    let upsert = store.upsert(key, &value, 1);
+    let upsert = store.upsert(&key, &value, 1);
     assert!(upsert == status::OK || upsert == status::PENDING);
 
-    let (res, recv): (u8, Receiver<String>) = store.read(key, 1);
+    let (res, recv): (u8, Receiver<String>) = store.read(&key, 1);
     assert_eq!(res, status::OK);
     assert_eq!(recv.recv().unwrap(), value);
 
-    let rmw = store.rmw(key, &modification, 1);
+    let rmw = store.rmw(&key, &modification, 1);
     assert!(rmw == status::OK || rmw == status::PENDING);
 
-    let (res, recv): (u8, Receiver<String>) = store.read(key, 1);
+    let (res, recv): (u8, Receiver<String>) = store.read(&key, 1);
     assert_eq!(res, status::OK);
     assert_eq!(recv.recv().unwrap(), String::from("Hello, World!"));
 }
@@ -127,17 +127,17 @@ fn faster_rmw_vec() {
     let value = vec![0, 1, 2];
     let modification = vec![3, 4, 5];
 
-    let upsert = store.upsert(key, &value, 1);
+    let upsert = store.upsert(&key, &value, 1);
     assert!(upsert == status::OK || upsert == status::PENDING);
 
-    let (res, recv): (u8, Receiver<Vec<i32>>) = store.read(key, 1);
+    let (res, recv): (u8, Receiver<Vec<i32>>) = store.read(&key, 1);
     assert_eq!(res, status::OK);
     assert_eq!(recv.recv().unwrap(), value);
 
-    let rmw = store.rmw(key, &modification, 1);
+    let rmw = store.rmw(&key, &modification, 1);
     assert!(rmw == status::OK || rmw == status::PENDING);
 
-    let (res, recv): (u8, Receiver<Vec<i32>>) = store.read(key, 1);
+    let (res, recv): (u8, Receiver<Vec<i32>>) = store.read(&key, 1);
     assert_eq!(res, status::OK);
     assert_eq!(recv.recv().unwrap(), vec![0, 1, 2, 3, 4, 5]);
 }

--- a/tests/checkpoint_tests.rs
+++ b/tests/checkpoint_tests.rs
@@ -14,7 +14,7 @@ fn single_checkpoint() {
     let value: u64 = 100;
 
     for key in 0..1000 {
-        store.upsert(key as u64, &value, key);
+        store.upsert(&(key as u64), &value, key);
     }
 
     let checkpoint = store.checkpoint().unwrap();

--- a/tests/thread_tests.rs
+++ b/tests/thread_tests.rs
@@ -20,7 +20,7 @@ fn multi_threaded_test() {
     let modification: u64 = 30;
 
     for key in 0..ops {
-        store.upsert(key as u64, &initial_value, key);
+        store.upsert(&(key as u64), &initial_value, key);
     }
 
     let num_threads = 4;
@@ -32,7 +32,7 @@ fn multi_threaded_test() {
             let _session = store.start_session();
 
             for key in 0..ops {
-                store.rmw(key as u64, &modification, key);
+                store.rmw(&(key as u64), &modification, key);
             }
 
             // Make sure everything is completed
@@ -49,7 +49,7 @@ fn multi_threaded_test() {
 
     for key in 0..ops {
         let expected_value = initial_value + (modification * num_threads);
-        let (_res, recv): (u8, Receiver<u64>) = store.read(key, key);
+        let (_res, recv): (u8, Receiver<u64>) = store.read(&key, key);
         assert_eq!(recv.recv().unwrap(), expected_value);
     }
 }


### PR DESCRIPTION
What:
* allow arbitrary serialisable types to be used as keys

Why:
* more general interface than only allowing u64s

Requires:
* https://github.com/faster-rs/FASTER/pull/9

Closes #4 