### PR TITLE
Simplify faster generics

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "faster-rs"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Max Meldrum <mmeldrum@kth.se>", "Matthew Brookes <mbrookes1304@gmail.com>"]
 edition = "2018"
 keywords = ["concurrent", "embedded", "key-value-store"]
@@ -12,7 +12,7 @@ readme = "README.md"
 [dependencies]
 bincode = "1.1.2"
 libc = "0.2"
-libfaster-sys = { path = "libfaster-sys", version = "0.2.0" }
+libfaster-sys = { path = "libfaster-sys", version = "0.3.0" }
 serde = "1.0.89"
 serde_derive = "1.0.89"
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/faster-rs/faster-rs)
-[![Cargo](https://img.shields.io/badge/crates.io-0.2.0-orange.svg)](https://crates.io/crates/faster-rs)
+[![Cargo](https://img.shields.io/badge/crates.io-0.3.0-orange.svg)](https://crates.io/crates/faster-rs)
 [![Build Status](https://dev.azure.com/faster-rs/faster-rs/_apis/build/status/faster-rs.faster-rs?branchName=master)](https://dev.azure.com/faster-rs/faster-rs/_build/latest?definitionId=1&branchName=master)
 
 # Experimental FASTER wrapper for Rust

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ struct MyValue {
     bar: String,
 }
 
-impl FasterValue<'_, MyValue> for MyValue {
+impl FasterValue for MyValue {
     fn rmw(&self, _modification: MyValue) -> MyValue {
         unimplemented!()
     }

--- a/examples/custom_values.rs
+++ b/examples/custom_values.rs
@@ -12,7 +12,7 @@ struct MyValue {
     bar: String,
 }
 
-impl FasterValue<'_, MyValue> for MyValue {
+impl FasterValue for MyValue {
     fn rmw(&self, _modification: MyValue) -> MyValue {
         unimplemented!()
     }

--- a/libfaster-sys/Cargo.toml
+++ b/libfaster-sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "libfaster-sys"
 description = "Bindings for FASTER"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Max Meldrum <mmeldrum@kth.se>", "Matthew Brookes <mbrookes1304@gmail.com>"]
 edition = "2018"
 repository = "https://github.com/faster-rs/faster-rs.git"

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -3,13 +3,13 @@ use crate::FasterKey;
 use serde::{Deserialize, Serialize};
 use std::ops::Add;
 
-impl<'a, T> FasterKey<'a, T> for T where T: Serialize + Deserialize<'a> {}
+impl<T> FasterKey for T where T: Serialize + Deserialize<'static> {}
 
 macro_rules! primitive_impl {
     ($ty:ident, $method:ident $($cast:tt)*) => {
-        impl<'a> FasterValue<'a, $ty> for $ty {
+        impl FasterValue for $ty {
             #[inline]
-            fn rmw(&self, modification: $ty) -> $ty {
+            fn rmw(&self, modification: Self) -> Self {
                 $method(*self, modification)
             }
         }
@@ -18,9 +18,9 @@ macro_rules! primitive_impl {
 
 macro_rules! owned_impl {
     ($ty:ident, $method:ident $($cast:tt)*) => {
-        impl<'a> FasterValue<'a, $ty> for $ty {
+        impl FasterValue for $ty {
             #[inline]
-            fn rmw(&self, modification: $ty) -> $ty {
+            fn rmw(&self, modification: Self) -> Self {
                 $method(self, modification)
             }
         }
@@ -60,7 +60,7 @@ fn rmw_string(old: &String, new: String) -> String {
 }
 owned_impl!(String, rmw_string);
 
-impl<'a, T: Clone + Serialize + Deserialize<'a>> FasterValue<'a, Vec<T>> for Vec<T> {
+impl<T: Clone + Serialize + Deserialize<'static>> FasterValue for Vec<T> {
     #[inline]
     fn rmw(&self, new: Vec<T>) -> Vec<T> {
         let mut result = Vec::with_capacity(self.len() + new.len());


### PR DESCRIPTION
What:
* Remove all those horrible generic & lifetime parameters from `FasterKey` and `FasterValue`
* Update `Cargo.toml` in preparation for `0.3.0` release

Why:
* The interface is much cleaner this way
* Let's release a new version ;p