### PR TITLE
In-memory FASTER

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "faster-rs"
-version = "0.5.3"
+version = "0.6.0"
 authors = ["Max Meldrum <mmeldrum@kth.se>", "Matthew Brookes <mbrookes1304@gmail.com>"]
 edition = "2018"
 keywords = ["concurrent", "embedded", "key-value-store"]
@@ -12,7 +12,7 @@ readme = "README.md"
 [dependencies]
 bincode = "1.1.2"
 libc = "0.2"
-libfaster-sys = { path = "libfaster-sys", version = "0.5.3" }
+libfaster-sys = { path = "libfaster-sys", version = "0.6.0" }
 serde = "1.0.89"
 serde_derive = "1.0.89"
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/faster-rs/faster-rs)
-[![Cargo](https://img.shields.io/badge/crates.io-0.5.0-orange.svg)](https://crates.io/crates/faster-rs)
+[![Cargo](https://img.shields.io/crates/v/faster-rs.svg)](https://crates.io/crates/faster-rs)
 [![Build Status](https://dev.azure.com/faster-rs/faster-rs/_apis/build/status/faster-rs.faster-rs?branchName=master)](https://dev.azure.com/faster-rs/faster-rs/_build/latest?definitionId=1&branchName=master)
 
 # Experimental FASTER wrapper for Rust
 
 ```toml
 [dependencies]
-faster-rs = "0.5.0"
+faster-rs = "0.6.0"
 ```
 
 Includes experimental C interface for FASTER. It is a generic implementation of FASTER that allows arbitrary Key-Value pairs to be stored. This wrapper is only focusing on Linux support.

--- a/examples/sum_store_single.rs
+++ b/examples/sum_store_single.rs
@@ -78,7 +78,7 @@ fn recover(token: String) -> () {
     println!("Attempting to recover");
     if let Ok(recover_store) = FasterKv::new(TABLE_SIZE, LOG_SIZE, STORAGE_DIR.to_string()) {
         match recover_store.recover(token.clone(), token.clone()) {
-            Some(rec) => {
+            Ok(rec) => {
                 println!("Recover version: {}", rec.version);
                 println!("Recover status: {}", rec.status);
                 println!("Recovered sessions: {:?}", rec.session_ids);
@@ -119,7 +119,7 @@ fn recover(token: String) -> () {
                 println!("{} incorrect recoveries", incorrect);
                 recover_store.stop_session();
             }
-            None => println!("Recover operation failed"),
+            Err(_) => println!("Recover operation failed"),
         }
     } else {
         println!("{}", "Failed to create recover store");

--- a/libfaster-sys/Cargo.toml
+++ b/libfaster-sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "libfaster-sys"
 description = "Bindings for FASTER"
-version = "0.5.3"
+version = "0.6.0"
 authors = ["Max Meldrum <mmeldrum@kth.se>", "Matthew Brookes <mbrookes1304@gmail.com>"]
 edition = "2018"
 repository = "https://github.com/faster-rs/faster-rs.git"

--- a/tests/checkpoint_tests.rs
+++ b/tests/checkpoint_tests.rs
@@ -1,7 +1,7 @@
 extern crate faster_rs;
 extern crate tempfile;
 
-use faster_rs::FasterKv;
+use faster_rs::{FasterError, FasterKv};
 use tempfile::TempDir;
 
 #[test]
@@ -61,4 +61,61 @@ fn single_checkpoint_hybrid_log() {
 #[test]
 fn concurrent_checkpoints() {
     //TODO
+}
+
+#[test]
+fn in_memory_checkpoint_errors() {
+    let table_size: u64 = 1 << 14;
+    let log_size: u64 = 17179869184;
+    let store = FasterKv::new_in_memory(table_size, log_size);
+    let value: u64 = 100;
+
+    for key in 0..1000 {
+        store.upsert(&(key as u64), &value, key);
+    }
+
+    let checkpoint = store.checkpoint();
+    assert!(checkpoint.is_err(), "Checkpoint should fail");
+    match checkpoint.err().unwrap() {
+        FasterError::InvalidType => assert!(true),
+        _ => assert!(false, "Should give InvalidType Error"),
+    }
+}
+
+#[test]
+fn in_memory_checkpoint_index_errors() {
+    let table_size: u64 = 1 << 14;
+    let log_size: u64 = 17179869184;
+    let store = FasterKv::new_in_memory(table_size, log_size);
+    let value: u64 = 100;
+
+    for key in 0..1000 {
+        store.upsert(&(key as u64), &value, key);
+    }
+
+    let checkpoint = store.checkpoint_index();
+    assert!(checkpoint.is_err(), "Checkpoint should fail");
+    match checkpoint.err().unwrap() {
+        FasterError::InvalidType => assert!(true),
+        _ => assert!(false, "Should give InvalidType Error"),
+    }
+}
+
+#[test]
+fn in_memory_checkpoint_hybrid_log_errors() {
+    let table_size: u64 = 1 << 14;
+    let log_size: u64 = 17179869184;
+    let store = FasterKv::new_in_memory(table_size, log_size);
+    let value: u64 = 100;
+
+    for key in 0..1000 {
+        store.upsert(&(key as u64), &value, key);
+    }
+
+    let checkpoint = store.checkpoint_hybrid_log();
+    assert!(checkpoint.is_err(), "Checkpoint should fail");
+    match checkpoint.err().unwrap() {
+        FasterError::InvalidType => assert!(true),
+        _ => assert!(false, "Should give InvalidType Error"),
+    }
 }


### PR DESCRIPTION
What:
* add an option for in-memory FASTER
* add a new Error type
* return error when doing checkpoint/recover for an in-memory instance

Why:
* FASTER supports a pure in-memory `HybridLog` so we should too
* there's currently a mix of `Result` and `Option` which I think is better unified in one Error type
* want to try and prevent checkpoint/recover that makes no sense

Closes #14 