### PR TITLE
RMW: support growing types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "faster-rs"
-version = "0.8.1"
+version = "0.8.2"
 authors = ["Max Meldrum <mmeldrum@kth.se>", "Matthew Brookes <mbrookes1304@gmail.com>"]
 edition = "2018"
 keywords = ["concurrent", "embedded", "key-value-store"]
@@ -12,7 +12,7 @@ readme = "README.md"
 [dependencies]
 bincode = "1.1.2"
 libc = "0.2"
-libfaster-sys = { path = "libfaster-sys", version = "0.8" }
+libfaster-sys = { path = "libfaster-sys", version = "0.8.1" }
 serde = "1.0.89"
 serde_derive = "1.0.89"
 

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ fn main() {
 ## Using custom values
 `struct`s that can be (de)serialised using [serde](https://crates.rs/crates/serde) are supported as values. In order to use such a `struct`, it is necessary to derive the implementations of `Serializable` and `Deserializable` from `serde-derive`.
 
-In order to use Read-Modify-Write operations on a custom type, it is also necessary to implement the `FasterRmw` trait which exposes an `rmw()` function. This function can be used to implement custom logic for Read-Modify-Write operations. Currently, it is only safe to perform RMW operations that do not increase the serialised size of the Value. For example, addition of numbers is fine but attempting to enlarge a `Vec` or `String` will corrupt the FASTER instance.
+In order to use Read-Modify-Write operations on a custom type, it is also necessary to implement the `FasterRmw` trait which exposes an `rmw()` function. This function can be used to implement custom logic for Read-Modify-Write operations.
 
 The following example shows a basic struct being used as a value. Try it out by running `cargo run --example custom_values`.
 
@@ -210,6 +210,7 @@ fn main() {
 Several types already implement `FasterRmw` along with providing Read-Modify-Write logic. The implementations can be found in `src/impls.rs` but their RMW logic is summarised here:
 * Numeric types use addition
 * Bools and Chars replace old value for new value
+* Strings and Vec<T> append modification
 
 ## Checkpoint and Recovery
 FASTER's fault tolerance is provided by [Concurrent Prefix Recovery](https://www.microsoft.com/en-us/research/uploads/prod/2019/01/cpr-sigmod19.pdf) (CPR). It provides the following semantics:

--- a/libfaster-sys/Cargo.toml
+++ b/libfaster-sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "libfaster-sys"
 description = "Bindings for FASTER"
-version = "0.8.0"
+version = "0.8.1"
 authors = ["Max Meldrum <mmeldrum@kth.se>", "Matthew Brookes <mbrookes1304@gmail.com>"]
 edition = "2018"
 repository = "https://github.com/faster-rs/faster-rs.git"

--- a/src/faster_traits.rs
+++ b/src/faster_traits.rs
@@ -60,11 +60,6 @@ where
 pub trait FasterRmw: DeserializeOwned + Serialize {
     /// Specify custom Read-Modify-Write logic
     ///
-    /// # Warning
-    /// The size of the new value must be no larger than that of the original value.
-    ///
-    /// Failing to ensure this will probably corrupt your FASTER instance.
-    ///
     /// # Example
     /// ```
     /// use faster_rs::{status, FasterKv, FasterRmw};


### PR DESCRIPTION
What:
* update FASTER wrapper to include support for "growing" types (https://github.com/faster-rs/FASTER/pull/11 needs merging)
* add RMW implementation for Vec and String

Why:
* allows RMW workloads for types that don't stay the same size